### PR TITLE
Equilibration on general meshes

### DIFF
--- a/cpp/BoundaryData.cpp
+++ b/cpp/BoundaryData.cpp
@@ -343,10 +343,19 @@ BoundaryData<T>::BoundaryData(
 
           for (auto pnt : pnts_fct)
           {
-            _pnt_on_esnt_boundary[pnt] = true;
+            _pnt_on_esnt_boundary[pnt] += 1;
           }
         }
       }
+    }
+  }
+
+  // Finalise markers for pure essential stress BCs
+  if (reconstruct_stress && (_gdim == 2))
+  {
+    for (std::size_t i = 0; i < _pnt_on_esnt_boundary.size(); ++i)
+    {
+      _pnt_on_esnt_boundary[i] = (_pnt_on_esnt_boundary[i] == 4) ? true : false;
     }
   }
 }

--- a/cpp/BoundaryData.cpp
+++ b/cpp/BoundaryData.cpp
@@ -337,7 +337,7 @@ BoundaryData<T>::BoundaryData(
           x_bvals[boundary_dofs_fct[i]] = boundary_values_fct[i];
         }
 
-        if ((reconstruct_stress) && (i_rhs < (_gdim - 1)))
+        if ((reconstruct_stress) && (i_rhs < _gdim))
         {
           std::span<const std::int32_t> pnts_fct = fct_to_pnt->links(fct);
 

--- a/cpp/BoundaryData.hpp
+++ b/cpp/BoundaryData.hpp
@@ -121,6 +121,11 @@ public:
   }
 
   /// Marker if mesh-node is on essential boundary of the stress field
+  ///
+  /// Essential boundary:
+  ///    - Node resp. patch around node in on boundary of the domain
+  ///    - All stress rows have pure neumann BCs on patch
+  ///
   /// @return List of markers for all nodes
   std::span<const std::int8_t> node_on_essnt_boundary_stress() const
   {
@@ -249,7 +254,7 @@ protected:
   std::vector<std::int32_t> _offset_dofdata;
 
   // --- Data per node
-  // The boundary markers
+  // The boundary markers (patch has purely essential BCs)
   std::vector<std::int8_t> _pnt_on_esnt_boundary;
 
   // --- Data per facet

--- a/cpp/Patch.cpp
+++ b/cpp/Patch.cpp
@@ -429,8 +429,8 @@ Patch::next_facet_triangle(std::int32_t cell_i,
 // ---------------------------------------------------------------------------------------------------
 OrientedPatch::OrientedPatch(std::shared_ptr<const mesh::Mesh> mesh,
                              mdspan_t<const std::int8_t, 2> bfct_type,
-                             const int ncells_crit,
-                             std::span<const std::int8_t> pnts_on_bndr)
+                             std::span<const std::int8_t> pnts_on_bndr,
+                             const int ncells_min, const int ncells_crit)
     : _mesh(mesh), _bfct_type(bfct_type), _dim(mesh->geometry().dim()),
       _dim_fct(mesh->geometry().dim() - 1),
       _type(bfct_type.extent(0), PatchType::internal),
@@ -445,8 +445,8 @@ OrientedPatch::OrientedPatch(std::shared_ptr<const mesh::Mesh> mesh,
   _cell_to_node = _mesh->topology().connectivity(_dim, 0);
 
   // The patch size
-  set_max_patch_size(mesh->topology().index_map(0)->size_local(), ncells_crit,
-                     pnts_on_bndr);
+  set_max_patch_size(mesh->topology().index_map(0)->size_local(), pnts_on_bndr,
+                     ncells_min, ncells_crit);
 
   // Initialize number of facets per cell
   _fct_per_cell = _cell_to_fct->links(0).size();
@@ -474,110 +474,102 @@ OrientedPatch::OrientedPatch(std::shared_ptr<const mesh::Mesh> mesh,
   }
 }
 
-PatchType OrientedPatch::determine_patch_type(const std::int32_t node_i) const
-{
-  // Get facets on patch
-  std::span<const std::int32_t> fcts_patch = _node_to_fct->links(node_i);
-
-  // Check facet types
-  int count_pessnt_bfct = 0;
-  int count_dessnt_dfct = 0;
-
-  for (std::int32_t fct : fcts_patch)
-  {
-    if (_bfct_type(0, fct) == PatchFacetType::essnt_primal)
-    {
-      count_pessnt_bfct += 1;
-    }
-    else if (_bfct_type(0, fct) == PatchFacetType::essnt_dual)
-    {
-      count_dessnt_dfct += 1;
-    }
-  }
-
-  // Determine patch type
-  if ((count_dessnt_dfct + count_pessnt_bfct) == 0)
-  {
-    return PatchType::internal;
-  }
-  else
-  {
-    if (count_pessnt_bfct == 2)
-    {
-      return PatchType::bound_essnt_primal;
-    }
-    else if (count_dessnt_dfct == 2)
-    {
-      return PatchType::bound_essnt_dual;
-    }
-    else
-    {
-      return PatchType::bound_mixed;
-    }
-  }
-}
-
 std::vector<std::int32_t> OrientedPatch::group_boundary_patches(
-    const std::int32_t node_i, std::span<const std::int8_t> pnt_on_essntbndr,
+    const std::int32_t node_i, std::span<const std::int8_t> pnts_on_bndr,
     const int ncells_min, const int ncells_crit) const
 {
+  // Initialisation
+  std::vector<std::int32_t> grouped_patches;
 
-  // FIXME -- Check only on boundary patch neighbored by node_i --> Extend!
-
-  // Get adjacent internal patch
-  std::int32_t node_i_internal = get_adjacent_internal_patch(node_i);
-
-  // Initialise vector for adjacent patches
-  std::vector<std::int32_t> grouped_patches = {node_i_internal, node_i};
-
-  // Facets on patch
-  std::span<const std::int32_t> fcts_patch = _node_to_fct->links(node_i);
-
-  // Get adjacent boundary patches
-  for (std::int32_t fct_i : fcts_patch)
+  // Check the actual boundary patch
+  if (ncells(node_i) == ncells_crit)
   {
-    // Node on current facet
-    std::span<const std::int32_t> nodes_fct = _fct_to_node->links(fct_i);
+    // Storage for neighboring patches
+    std::array<std::int32_t, 2> neighbor_pnts, neighbor_fcts;
 
-    // Check compatibility of adjacent (boundary) patches
-    int nodei_adjacent = (nodes_fct[0] == node_i) ? nodes_fct[1] : nodes_fct[0];
+    // Facets on current patch
+    std::span<const std::int32_t> fcts_patch = _node_to_fct->links(node_i);
 
-    if (pnt_on_essntbndr[nodei_adjacent])
+    // Check if one of the stress patches if of type bound_essnt_dual
+    int count_bfcts = 0;
+
+    for (std::int32_t fct : fcts_patch)
     {
-      // Cells on adjacent boundary patch
-      int ncells_adjacet_patch = ncells(nodei_adjacent);
-
-      if (ncells_adjacet_patch > ncells_min)
+      // Check if patch is of type bound_essnt_dual
+      if (_bfct_type(0, fct) != PatchFacetType::internal)
       {
-        if (ncells_adjacet_patch == ncells_crit)
+        // Get nodes on facet
+        std::span<const std::int32_t> nodes_fct = _fct_to_node->links(fct);
+
+        // Check if facet is on neumann boundary
+        if ((pnts_on_bndr[nodes_fct[0]]) && (pnts_on_bndr[nodes_fct[1]]))
         {
-          // Check if adjacent patch is pure neumann-patch
-          // FIXME - Currently only for 2D
-          int count_efcts = 0;
-          std::span<const std::int32_t> fcts_adjacet_patch
-              = _node_to_fct->links(nodei_adjacent);
+          // Get nodes on facet
+          std::span<const std::int32_t> nodes_fct = _fct_to_node->links(fct);
 
-          for (std::int32_t fct_ap_i : fcts_adjacet_patch)
-          {
-            if ((_bfct_type(0, fct_ap_i) == PatchFacetType::essnt_dual)
-                || (_bfct_type(1, fct_ap_i) == PatchFacetType::essnt_dual))
-            {
-              count_efcts += 1;
-            }
-          }
+          // Store central node of neighboring patch
+          neighbor_pnts[count_bfcts]
+              = (nodes_fct[0] == node_i) ? nodes_fct[1] : nodes_fct[0];
 
-          if (count_efcts == 2)
-          {
-            grouped_patches.push_back(nodei_adjacent);
-          }
+          // Store common facet with neighboring patch
+          neighbor_fcts[count_bfcts] = fct;
+
+          // Increment counter
+          count_bfcts += 1;
         }
       }
-      else
+    }
+
+    if (count_bfcts == 2)
+    {
+      // Get adjacent internal patch
+      std::int32_t node_i_internal = adjacent_internal_patch(node_i);
+      grouped_patches.push_back(node_i_internal);
+
+      // Append list of grouped patches
+      grouped_patches.push_back(node_i);
+
+      // Check adjacent patches
+      for (int i = 0; i < 2; i++)
       {
-        std::string error_msg = "Patch around node "
-                                + std::to_string(nodei_adjacent) + " has only "
-                                + std::to_string(ncells_min) + " cells";
-        throw std::runtime_error(error_msg);
+        std::int32_t neighbor_pnt = neighbor_pnts[i];
+        std::int32_t neighbor_fct = neighbor_fcts[i];
+        bool proceed_search = true;
+
+        while (proceed_search && (ncells(neighbor_pnt) == ncells_crit))
+        {
+          // Check if patch is of type bound_essnt_dual
+          std::span<const std::int32_t> fcts_patch
+              = _node_to_fct->links(neighbor_pnt);
+
+          for (std::int32_t fct : fcts_patch)
+          {
+            if ((_bfct_type(0, fct) != PatchFacetType::internal)
+                && (fct != neighbor_fct))
+            {
+              // Get nodes on facet
+              std::span<const std::int32_t> nodes_fct
+                  = _fct_to_node->links(fct);
+
+              // Check if patch is on essential boundary
+              if ((pnts_on_bndr[nodes_fct[0]]) && (pnts_on_bndr[nodes_fct[1]]))
+              {
+                // Append list of grouped patches
+                grouped_patches.push_back(neighbor_pnt);
+
+                // Data for next patch
+                neighbor_pnt = (nodes_fct[0] == neighbor_pnt) ? nodes_fct[1]
+                                                              : nodes_fct[0];
+                neighbor_fct = fct;
+              }
+              else
+              {
+                proceed_search = false;
+              }
+              break;
+            }
+          }
+        }
       }
     }
   }
@@ -611,23 +603,34 @@ bool OrientedPatch::reversion_required(int index) const
 
 // --- Protected methods
 void OrientedPatch::set_max_patch_size(
-    const int nnodes_proc, const int ncells_crit,
-    std::span<const std::int8_t> pnts_on_bndr)
+    const int nnodes_proc, std::span<const std::int8_t> pnts_on_bndr,
+    const int ncells_min, const int ncells_crit)
 {
   // Initialization
   _ncells_max = 0;
   _groupsize_max = 1;
 
-  if (ncells_crit == 0)
+  if (ncells_crit == 1)
   {
     for (std::size_t i_node = 0; i_node < nnodes_proc; ++i_node)
     {
       // Get number of cells on patch
       int n_cells = _node_to_cell->links(i_node).size();
 
-      if (n_cells > _ncells_max)
+      // Check patch size
+      if (n_cells == ncells_min)
       {
-        _ncells_max = n_cells;
+        std::string error_msg = "Patch around node " + std::to_string(i_node)
+                                + " has only " + std::to_string(ncells_min)
+                                + " cells.";
+        throw std::runtime_error(error_msg);
+      }
+      else
+      {
+        if (n_cells > _ncells_max)
+        {
+          _ncells_max = n_cells;
+        }
       }
     }
   }
@@ -639,54 +642,30 @@ void OrientedPatch::set_max_patch_size(
       // Get number of cells on patch
       int n_cells = _node_to_cell->links(node_i).size();
 
-      // Check if maximal patch size hast to be updated
-      if (n_cells > _ncells_max)
+      // Check patch size
+      if (n_cells == ncells_min)
       {
-        _ncells_max = n_cells;
+        std::string error_msg = "Patch around node " + std::to_string(node_i)
+                                + " has only " + std::to_string(ncells_min)
+                                + " cells.";
+        throw std::runtime_error(error_msg);
+      }
+      else
+      {
+        if (n_cells > _ncells_max)
+        {
+          _ncells_max = n_cells;
+        }
       }
 
       // Check if patches have to be grouped
-      if ((pnts_on_bndr[node_i]) && (n_cells == ncells_crit))
+      std::vector<std::int32_t> grouped_bndr_patches = group_boundary_patches(
+          node_i, pnts_on_bndr, ncells_min, ncells_crit);
+      int groupsize = grouped_bndr_patches.size() - 1;
+
+      if (groupsize > _groupsize_max)
       {
-        // Check patch type
-        PatchType patch_type = determine_patch_type(node_i);
-
-        if (patch_type == PatchType::bound_essnt_dual)
-        {
-          // Increment group size
-          int groupsize = 2;
-
-          // Adjacent boundary facets
-          std::array<std::int32_t, 2> adjacent_patches
-              = adjacent_boundary_patches(node_i);
-
-          // Check if adjacet patches are also small
-          for (std::int32_t node : adjacent_patches)
-          {
-            std::int32_t node_i_adjacent = node;
-
-            while (ncells(node_i_adjacent) == ncells_crit)
-            {
-              // Increment group size
-              groupsize += 1;
-
-              // Get adjacent boundary patches
-              std::array<std::int32_t, 2> adjacent_patches
-                  = adjacent_boundary_patches(node_i_adjacent);
-
-              // Update node_i
-              node_i_adjacent = (adjacent_patches[0] == node_i)
-                                    ? adjacent_patches[1]
-                                    : adjacent_patches[0];
-            }
-          }
-
-          // Check if  maximal group size has to be updated
-          if (groupsize > _groupsize_max)
-          {
-            _groupsize_max = groupsize;
-          }
-        }
+        _groupsize_max = groupsize;
       }
     }
   }
@@ -1047,31 +1026,27 @@ std::int32_t OrientedPatch::next_facet(std::int32_t cell_i,
   return fct_next;
 }
 
-std::array<std::int32_t, 2>
-OrientedPatch::adjacent_boundary_patches(const std::int32_t node_i) const
+std::int32_t
+OrientedPatch::adjacent_internal_patch(const std::int32_t node_i) const
 {
-  // Initialisation
-  std::array<std::int32_t, 2> adjacent_patches;
-
-  // Facets on current patch
+  // Facets on patch
   std::span<const std::int32_t> fcts_patch = _node_to_fct->links(node_i);
 
-  // Loop over facets
-  int count = 0;
+  // Adjacent internal patch
+  std::int32_t inner_node;
+
   for (std::int32_t fct : fcts_patch)
   {
-    // Check compatibility of adjacent (boundary) patches
-    if (_bfct_type(0, fct) != PatchFacetType::internal)
+    if (_bfct_type(0, fct) == PatchFacetType::internal)
     {
-      // Nodes on current facet
-      std::span<const std::int32_t> pnts_fct = _fct_to_node->links(fct);
+      // Nodes on facet
+      std::span<const std::int32_t> nodes_fct = _fct_to_node->links(fct);
 
-      // Get central node of adjacet boundary patch
-      adjacent_patches[count]
-          = (pnts_fct[0] == node_i) ? pnts_fct[1] : pnts_fct[0];
-      count += 1;
+      // Output patch-central node
+      inner_node = (nodes_fct[0] == node_i) ? nodes_fct[1] : nodes_fct[0];
+      break;
     }
   }
 
-  return std::move(adjacent_patches);
+  return inner_node;
 }

--- a/cpp/Patch.cpp
+++ b/cpp/Patch.cpp
@@ -457,7 +457,7 @@ OrientedPatch::OrientedPatch(std::shared_ptr<const mesh::Mesh> mesh,
     const int sp1 = _ncells_max + 1, sp2 = _ncells_max + 2;
 
     _cells.resize(sp2);
-    _fcts.resize(sp1);
+    _fcts.resize(sp2);
     _fcts_sorted.resize(sp1);
     _fcts_local.resize(2 * sp1);
     _inodes_local.resize(sp2);
@@ -867,7 +867,7 @@ void OrientedPatch::initialize_patch(const int node_i)
     _inodes_local[a] = node_local(cell_a, _nodei);
 
     // Determine next facet
-    _fcts[a + 1] = next_facet(cell_ap1, fcts_cell_ap1, lfct_cell_ap1);
+    _fcts[ap1] = next_facet(cell_ap1, fcts_cell_ap1, lfct_cell_ap1);
   }
 
   // Complete Definition of patch

--- a/cpp/Patch.hpp
+++ b/cpp/Patch.hpp
@@ -374,13 +374,12 @@ public:
   /// @param pnt_on_bndr      Markers for all mesh nodes on essential boundary
   ///                         (stresses)
   /// @param initial_length   Initial length of the output vector
-  /// @param ncells_min       Minimum number of cells on adjacent patches
-  /// @param ncells_crit      Critical number of cells on adjacent patches
+  /// @param ncells_crit      Critical number of cells on patches
   /// @return                 The central nodes of critical, adjacent patches
   std::vector<std::int32_t>
   group_boundary_patches(const std::int32_t node_i,
                          std::span<const std::int8_t> pnt_on_bndr,
-                         const int ncells_min, const int ncells_crit) const;
+                         const int ncells_crit) const;
 
   /// Construction of a sub-DOFmap on each patch
   ///

--- a/cpp/Patch.hpp
+++ b/cpp/Patch.hpp
@@ -352,62 +352,34 @@ public:
   /// Storage is designed for the maximum patch size occurring within
   /// the current mesh.
   ///
-  /// @param mesh        The current mesh
-  /// @param bfct_type   List with type of all boundary facets
-  /// @param ncells_crit Critical number of cells on adjacent boundary patches
-  /// @param pnts_on_bndr Markers for all mesh nodes on boundary
+  /// @param mesh         The current mesh
+  /// @param bfct_type    List with type of all boundary facets
+  /// @param pnts_on_bndr Markers for all mesh nodes on stress boundary
+  /// @param ncells_min   Minimum number of cells patches (below: Error)
+  /// @param ncells_crit  Critical number of cells on a boundary patch
+  ///                     (modification required)
   OrientedPatch(std::shared_ptr<const mesh::Mesh> mesh,
-                mdspan_t<const std::int8_t, 2> bfct_type, const int ncells_crit,
-                std::span<const std::int8_t> pnts_on_essntbndr);
-
-  /// Determine type of an arbitrary patch
-  /// @param node_i Id of the patch-central node
-  /// @return The patch type
-  PatchType determine_patch_type(const std::int32_t node_i) const;
-
-  /// Returns an adjacent intern. patch of boundary patch
-  /// @param node_i Processor-local id of patch-central node
-  /// @return The patch-central node of the internal patch
-  std::int32_t get_adjacent_internal_patch(const std::int32_t node_i) const
-  {
-    // Facets on patch
-    std::span<const std::int32_t> fcts_patch = _node_to_fct->links(node_i);
-
-    // Adjacent internal patch
-    std::int32_t inner_node;
-
-    for (std::int32_t fct : fcts_patch)
-    {
-      if (_bfct_type(0, fct) == PatchFacetType::internal)
-      {
-        // Nodes on facet
-        std::span<const std::int32_t> nodes_fct = _fct_to_node->links(fct);
-
-        // Output patch-central node
-        inner_node = (nodes_fct[0] == node_i) ? nodes_fct[1] : nodes_fct[0];
-        break;
-      }
-    }
-
-    return inner_node;
-  }
+                mdspan_t<const std::int8_t, 2> bfct_type,
+                std::span<const std::int8_t> pnts_on_essntbndr,
+                const int ncells_min, const int ncells_crit);
 
   /// Group patches such that minimisation is possible
   ///
   /// Routine works only on boundary patches! It returns a list of adjacent
-  /// patches around node_i. Theby the patch is connected with one internal and
-  /// adjacent boundary patches (type PatchType::bound_essnt_dual) which have
-  /// ncells_crit cells.
+  /// patches around node_i. Thereby the patch is connected with one internal
+  /// and adjacent boundary patches (type PatchType::bound_essnt_dual) which
+  /// have ncells_crit cells.
   ///
   /// @param node_i           Processor-local id of patch-central node
-  /// @param pnt_on_essntbndr Markers for all mesh nodes on essential boundary
+  /// @param pnt_on_bndr      Markers for all mesh nodes on essential boundary
+  ///                         (stresses)
   /// @param initial_length   Initial length of the output vector
   /// @param ncells_min       Minimum number of cells on adjacent patches
   /// @param ncells_crit      Critical number of cells on adjacent patches
   /// @return                 The central nodes of critical, adjacent patches
   std::vector<std::int32_t>
   group_boundary_patches(const std::int32_t node_i,
-                         std::span<const std::int8_t> pnt_on_essntbndr,
+                         std::span<const std::int8_t> pnt_on_bndr,
                          const int ncells_min, const int ncells_crit) const;
 
   /// Construction of a sub-DOFmap on each patch
@@ -609,10 +581,12 @@ public:
 protected:
   /// Determine maximum patch size
   /// @param nnodes_proc  Number of nodes on current processor
-  /// @param ncells_crit  Critical number of cells on adjacent boundary patches
   /// @param pnts_on_bndr Markers for all mesh nodes on boundary
-  void set_max_patch_size(const int nnodes_proc, const int ncells_crit,
-                          std::span<const std::int8_t> pnts_on_bndr);
+  /// @param ncells_min   Minimum number of cells on a patch
+  /// @param ncells_crit  Critical number of cells on adjacent boundary patches
+  void set_max_patch_size(const int nnodes_proc,
+                          std::span<const std::int8_t> pnts_on_bndr,
+                          const int ncells_min, const int ncells_crit);
 
   /// Initializes patch
   ///
@@ -655,8 +629,10 @@ protected:
                           std::span<const std::int32_t> fct_cell_i,
                           std::int8_t id_fct_loc) const;
 
-  std::array<std::int32_t, 2>
-  adjacent_boundary_patches(const std::int32_t node_i) const;
+  /// Returns an adjacent intern. patch of boundary patch
+  /// @param node_i Processor-local id of patch-central node
+  /// @return The patch-central node of the internal patch
+  std::int32_t adjacent_internal_patch(const std::int32_t node_i) const;
 
   // Maximum size of patch
   int _ncells_max;

--- a/cpp/PatchCstm.hpp
+++ b/cpp/PatchCstm.hpp
@@ -24,16 +24,24 @@ public:
   ///
   /// @param mesh                    The current mesh
   /// @param bfct_type               List with type of all boundary facets
-  /// @param ncells_crit             Number of cells on critical patch
-  /// @param pnt_on_essntbndr        List with points on essential flux boundary
+  /// @param pnt_on_essntbndr        List with points on essential stress
+  /// boundary
+  ///                                (only for stress eqlb. required --> empty
+  ///                                else)
   /// @param function_space_fluxhdiv Function space of H(div) flux
   /// @param symconstr_required      Flag for constrained minimisation
+  /// @param ncells_min              Minimum number of cells patches
+  ///                                (below: Error)
+  /// @param ncells_crit             Critical number of cells on a boundary
+  ///                                patch (modification required)
   PatchCstm(std::shared_ptr<const mesh::Mesh> mesh,
-            mdspan_t<const std::int8_t, 2> bfct_type, const int ncells_crit,
+            mdspan_t<const std::int8_t, 2> bfct_type,
             std::span<const std::int8_t> pnt_on_essntbndr,
             std::shared_ptr<const fem::FunctionSpace> function_space_fluxhdiv,
-            const bool symconstr_required)
-      : OrientedPatch(mesh, bfct_type, ncells_crit, pnt_on_essntbndr),
+            const bool symconstr_required, const int ncells_min,
+            const int ncells_crit)
+      : OrientedPatch(mesh, bfct_type, pnt_on_essntbndr, ncells_min,
+                      ncells_crit),
         _symconstr_required(symconstr_required),
         _degree_elmt_fluxhdiv(
             function_space_fluxhdiv->element()->basix_element().degree() - 1),
@@ -611,23 +619,30 @@ public:
   /// @param mesh                    The current mesh
   /// @param bfct_type               List with type of all boundary facets
   /// @param ncells_crit             Number of cells on critical patch
-  /// @param pnt_on_essntbndr        List with points on essential flux boundary
+  /// @param pnt_on_essntbndr        List with points on essnt. stress boundary
+  ///                                (only for stress eqlb. required
+  ///                                 --> empty else)
   /// @param function_space_fluxhdiv Function space of H(div) flux
   /// @param function_space_fluxdg   Function space of projected flux
   /// @param basix_element_fluxdg    BasiX element of projected flux
   ///                                (continuous version for required
   ///                                entity_closure_dofs)
+  /// @param symconstr_required      Flag for constrained minimisation
+  /// @param ncells_min              Minimum number of cells patches
+  ///                                (below: Error)
+  /// @param ncells_crit             Critical number of cells on a boundary
+  ///                                patch (modification required)
   PatchFluxCstm(
       std::shared_ptr<const mesh::Mesh> mesh,
-      mdspan_t<const std::int8_t, 2> bfct_type, const int ncells_crit,
+      mdspan_t<const std::int8_t, 2> bfct_type,
       std::span<const std::int8_t> pnt_on_essntbndr,
       const std::shared_ptr<const fem::FunctionSpace> function_space_fluxhdiv,
       const std::shared_ptr<const fem::FunctionSpace> function_space_fluxdg,
       const basix::FiniteElement& basix_element_fluxdg,
-      const bool symconstr_required)
-      : PatchCstm<T, id_flux_order>(mesh, bfct_type, ncells_crit,
-                                    pnt_on_essntbndr, function_space_fluxhdiv,
-                                    symconstr_required),
+      bool symconstr_required = false, int ncells_min = 1, int ncells_crit = 1)
+      : PatchCstm<T, id_flux_order>(mesh, bfct_type, pnt_on_essntbndr,
+                                    function_space_fluxhdiv, symconstr_required,
+                                    ncells_min, ncells_crit),
         _degree_elmt_fluxdg(basix_element_fluxdg.degree()),
         _function_space_fluxdg(function_space_fluxdg),
         _entity_dofs_fluxcg(basix_element_fluxdg.entity_closure_dofs())

--- a/cpp/PatchData.hpp
+++ b/cpp/PatchData.hpp
@@ -172,12 +172,13 @@ public:
       dimension_minspaces(ncells, ncells + 1, ncells + 2);
 
       // Check if lagrangian multiplier is required
-      _meanvalue_condition_required = false;
+      _meanvalue_condition_required = true;
       int condition_count = 0;
 
       for (std::size_t i = 0; i < _gdim; ++i)
       {
-        if (type_patch[i] == PatchType::bound_essnt_dual)
+        if ((type_patch[i] == PatchType::bound_essnt_primal)
+            || (type_patch[i] == PatchType::bound_mixed))
         {
           condition_count += 1;
         }
@@ -185,7 +186,7 @@ public:
 
       if (condition_count == _gdim)
       {
-        _meanvalue_condition_required = true;
+        _meanvalue_condition_required = false;
       }
     }
 

--- a/cpp/minimise_flux.hpp
+++ b/cpp/minimise_flux.hpp
@@ -183,7 +183,7 @@ generate_flux_minimisation_kernel(KernelDataEqlb<T>& kernel_data,
   }
 }
 
-/// Generate kernel for the assembly stress minimsation user consideration of a
+/// Generate kernel for the assembly stress minimisation user consideration of a
 /// weak symmetry condition
 /// @tparam T              The scalar type
 /// @param type            The kernel type

--- a/cpp/reconstruction.hpp
+++ b/cpp/reconstruction.hpp
@@ -347,14 +347,6 @@ void reconstruct_fluxes_patch(ProblemDataFluxCstm<T>& problem_data)
       // Create Sub-DOFmap
       patch.create_subdofmap(i_node);
 
-      // Check if equilibration is possible
-      if (patch.ncells() == 1)
-      {
-        std::string error_msg = "Patch around node " + std::to_string(i_node)
-                                + " has only one cell";
-        throw std::runtime_error(error_msg);
-      }
-
       // Reinitialise patch-data
       patch_data.reinitialisation(patch.type(), patch.ncells());
 

--- a/cpp/reconstruction.hpp
+++ b/cpp/reconstruction.hpp
@@ -254,23 +254,13 @@ void reconstruct_fluxes_patch(ProblemDataFluxCstm<T>& problem_data)
       {
         if (pnt_on_stress_boundary[i_node] && perform_equilibration[i_node])
         {
-          // Number of nodes on patch
-          const int ncells_patch = patch.ncells(i_node);
-
           // Group the patches
           std::vector<std::int32_t> grouped_patches
-              = patch.group_boundary_patches(i_node, pnt_on_stress_boundary, 1,
-                                             2);
+              = patch.group_boundary_patches(i_node, pnt_on_stress_boundary, 2);
 
           // Check if modification of patch is required
           if (grouped_patches.size() >= 2)
           {
-            // TODO - Generalise implementation to arbitrary group sizes!
-            if (grouped_patches.size() > 2)
-            {
-              throw std::runtime_error("Unsupported patch-grouping required!");
-            }
-
             // Equilibration step 1: Explicit step and minimisation
             for (std::size_t i = grouped_patches.size(); i-- > 0;)
             {
@@ -283,6 +273,10 @@ void reconstruct_fluxes_patch(ProblemDataFluxCstm<T>& problem_data)
                 throw std::runtime_error("Incompatible mesh! To many patches "
                                          "with 2 cells on neumann boundary.");
               }
+              else
+              {
+                perform_equilibration[node_i] = false;
+              }
 
               // Create Sub-DOFmap
               patch.create_subdofmap(node_i);
@@ -291,7 +285,6 @@ void reconstruct_fluxes_patch(ProblemDataFluxCstm<T>& problem_data)
               patch_data.reinitialisation(patch.type(), patch.ncells());
 
               // Perform equilibration
-              perform_equilibration[node_i] = false;
               equilibrate_flux_semiexplt<T, id_flux_order>(
                   mesh->geometry(), patch, patch_data, problem_data,
                   kernel_data, kernel_fluxmin, kernel_fluxmin_l);

--- a/python/demo/demo_reconstruction_poisson.py
+++ b/python/demo/demo_reconstruction_poisson.py
@@ -18,6 +18,7 @@ holds. Dirichlet BCs are applied on the boundaries 2 and 4.
 import numpy as np
 from mpi4py import MPI
 import time
+import typing
 
 import dolfinx
 import dolfinx.fem as dfem
@@ -26,6 +27,11 @@ import ufl
 
 from dolfinx_eqlb.eqlb import fluxbc, FluxEqlbEV, FluxEqlbSE
 from dolfinx_eqlb.lsolver import local_projection
+from dolfinx_eqlb.eqlb.check_eqlb_conditions import (
+    check_divergence_condition,
+    check_jump_condition,
+    check_jump_condition_per_facet,
+)
 
 
 # --- The exact solution
@@ -125,7 +131,13 @@ def solve_primal_problem(elmt_order_prime, domain, facet_tags, ds):
 
 # --- The flux equilibration
 def equilibrate_flux(
-    Equilibrator, elmt_order_prime, elmt_order_eqlb, domain, facet_tags, uh_prime
+    Equilibrator,
+    elmt_order_prime,
+    elmt_order_eqlb,
+    domain,
+    facet_tags,
+    uh_prime,
+    check_equilibration: typing.Optional[bool] = True,
 ):
     # Set source term
     x = ufl.SpatialCoordinate(domain)
@@ -183,6 +195,25 @@ def equilibrate_flux(
 
     print(f"Equilibration solved in {timing:.4e} s")
 
+    # --- Check equilibration conditions ---
+    if check_equilibration:
+        # Check if reconstruction is in DRT
+        flux_is_dg = equilibrator.V_flux.element.basix_element.discontinuous
+
+        # Divergence condition
+        check_divergence_condition(
+            equilibrator.list_flux[0],
+            sigma_proj[0],
+            rhs_proj[0],
+            mesh=domain,
+            degree=elmt_order_eqlb,
+            flux_is_dg=flux_is_dg,
+        )
+
+        # The jump condition
+        if flux_is_dg:
+            check_jump_condition(equilibrator.list_flux[0], sigma_proj[0])
+
     return sigma_proj[0], equilibrator.list_flux[0]
 
 
@@ -192,7 +223,7 @@ if __name__ == "__main__":
     Equilibrator = FluxEqlbSE
 
     # The orders of the FE spaces
-    elmt_order_prime = 1
+    elmt_order_prime = 2
     elmt_order_eqlb = 2
 
     # The mesh resolution

--- a/python/dolfinx_eqlb/eqlb/check_eqlb_conditions.py
+++ b/python/dolfinx_eqlb/eqlb/check_eqlb_conditions.py
@@ -481,7 +481,7 @@ def check_jump_condition_per_facet(
             for i in range(0, error_cells.shape[0]):
                 tf = "true" if np.isclose(error_cells[i, 2], 1) else "false"
                 print(
-                    "cells: {0:d}, {1:d} - fct aligned: {2:s} - dof: {3:d} - error: {4:.2e}".format(
+                    "cells: {0:.0f}, {1:.0f} - fct aligned: {2:s} - dof: {3:.0f} - error: {4:.2e}".format(
                         error_cells[i, 0],
                         error_cells[i, 1],
                         tf,

--- a/python/dolfinx_eqlb/eqlb/check_eqlb_conditions.py
+++ b/python/dolfinx_eqlb/eqlb/check_eqlb_conditions.py
@@ -460,7 +460,10 @@ def check_jump_condition_per_facet(
                     perm_minus = fct_permutations[cells[1], if_minus]
 
                     # Relative error
-                    error = (flux_plus + flux_minus) / flux_plus
+                    error = max(
+                        abs((flux_plus + flux_minus) / flux_plus),
+                        abs((flux_plus + flux_minus) / flux_minus),
+                    )
 
                     # Set error information
                     if perm_plus == perm_minus:
@@ -472,14 +475,24 @@ def check_jump_condition_per_facet(
                             error_cells, [[cells[0], cells[1], 0, i, error]], axis=0
                         )
 
-        if error_cells.shape[0] == 0:
-            return True
-        else:
-            if print_debug_information:
-                print("Cells with jump error:")
-                print(error_cells)
+    if error_cells.shape[0] == 0:
+        return True
+    else:
+        if print_debug_information:
+            print("Cells with jump error:")
+            for i in range(0, error_cells.shape[0]):
+                tf = "true" if np.isclose(error_cells[i, 2], 1) else "false"
+                print(
+                    "cells: {0:d}, {1:d} - fct aligned: {2:s} - dof: {3:d} - error: {4:.2e}".format(
+                        error_cells[i, 0],
+                        error_cells[i, 1],
+                        tf,
+                        error_cells[i, 3],
+                        error_cells[i, 4],
+                    )
+                )
 
-            return False
+        return False
 
 
 def check_weak_symmetry_condition(sigma_eq: dfem.Function):

--- a/python/dolfinx_eqlb/eqlb/check_eqlb_conditions.py
+++ b/python/dolfinx_eqlb/eqlb/check_eqlb_conditions.py
@@ -454,16 +454,14 @@ def check_jump_condition_per_facet(
                     flux_minus = x_sig_rt[dof_minus] * (-sign_minus)
 
                 # check continuity of facet-normal flux
-                if not np.isclose(flux_plus + flux_minus, 0):
+                fsum_lr = flux_plus + flux_minus
+                if not np.isclose(fsum_lr, 0):
                     # Get facet permutation
                     perm_plus = fct_permutations[cells[0], if_plus]
                     perm_minus = fct_permutations[cells[1], if_minus]
 
                     # Relative error
-                    error = max(
-                        abs((flux_plus + flux_minus) / flux_plus),
-                        abs((flux_plus + flux_minus) / flux_minus),
-                    )
+                    error = max(abs(fsum_lr / flux_plus), abs(fsum_lr / flux_minus))
 
                     # Set error information
                     if perm_plus == perm_minus:

--- a/python/test/unit/test_fluxeqlb_conditions.py
+++ b/python/test/unit/test_fluxeqlb_conditions.py
@@ -102,7 +102,7 @@ def test_equilibration_conditions(mesh_type, degree, bc_type, equilibrator):
 
                 # --- Check boundary conditions ---
                 if bc_type != "pure_dirichlet":
-                    eqlb_checker.check_boundary_conditions(
+                    boundary_condition = eqlb_checker.check_boundary_conditions(
                         sigma_eq[0],
                         sigma_projected,
                         boundary_dofvalues[0],
@@ -110,14 +110,25 @@ def test_equilibration_conditions(mesh_type, degree, bc_type, equilibrator):
                         boundary_id_neumann,
                     )
 
+                    if not boundary_condition:
+                        raise ValueError("Boundary conditions not fulfilled")
+
                 # --- Check divergence condition ---
-                eqlb_checker.check_divergence_condition(
+                div_condition = eqlb_checker.check_divergence_condition(
                     sigma_eq[0], sigma_projected, rhs_projected
                 )
 
+                if not div_condition:
+                    raise ValueError("Divergence condition not fulfilled")
+
                 # --- Check jump condition (only required for semi-explicit equilibrator)
                 if equilibrator == FluxEqlbSE:
-                    eqlb_checker.check_jump_condition(sigma_eq[0], sigma_projected)
+                    jump_condition = eqlb_checker.check_jump_condition(
+                        sigma_eq[0], sigma_projected
+                    )
+
+                    if not jump_condition:
+                        raise ValueError("Jump condition not fulfilled")
 
 
 if __name__ == "__main__":

--- a/python/test/unit/test_fluxeqlb_multirhs.py
+++ b/python/test/unit/test_fluxeqlb_multirhs.py
@@ -134,7 +134,7 @@ def test_equilibration_multi_rhs(degree, equilibrator):
                 raise ValueError("Equilibrated fluxes do not match!")
         else:
             # --- Check boundary conditions ---
-            eqlb_checker.check_boundary_conditions(
+            boundary_condition = eqlb_checker.check_boundary_conditions(
                 sigma_eq[i],
                 list_proj_flux[i],
                 boundary_dofvalues[i],
@@ -142,13 +142,24 @@ def test_equilibration_multi_rhs(degree, equilibrator):
                 list_bound_id_neumann[i],
             )
 
+            if not boundary_condition:
+                raise ValueError("Boundary conditions not fulfilled")
+
             # --- Check divergence condition ---
-            eqlb_checker.check_divergence_condition(
+            div_condition = eqlb_checker.check_divergence_condition(
                 sigma_eq[i], list_proj_flux[i], list_proj_rhs[i]
             )
 
+            if not div_condition:
+                raise ValueError("Divergence conditions not fulfilled")
+
             # --- Check jump condition (only required for semi-explicit equilibrator)
-            eqlb_checker.check_jump_condition(sigma_eq[i], list_proj_flux[i])
+            jump_condition = eqlb_checker.check_jump_condition(
+                sigma_eq[i], list_proj_flux[i]
+            )
+
+            if not jump_condition:
+                raise ValueError("Jump conditions not fulfilled")
 
 
 if __name__ == "__main__":

--- a/python/test/unit/test_stressqlb_conditions.py
+++ b/python/test/unit/test_stressqlb_conditions.py
@@ -128,13 +128,16 @@ def test_equilibration_conditions(mesh_type, degree, bc_type):
                 # --- Check boundary conditions ---
                 if bc_type != "pure_dirichlet":
                     for i in range(gdim):
-                        eqlb_checker.check_boundary_conditions(
+                        boundary_condition = eqlb_checker.check_boundary_conditions(
                             sigma_eq[i],
                             sigma_projected[i],
                             boundary_dofvalues[i],
                             geometry.facet_function,
                             boundary_id_neumann,
                         )
+
+                        if not boundary_condition:
+                            raise ValueError("Boundary conditions not fulfilled")
 
                 # --- Check divergence condition ---
                 stress_eq = ufl.as_matrix(
@@ -147,7 +150,7 @@ def test_equilibration_conditions(mesh_type, degree, bc_type):
                     ]
                 )
 
-                eqlb_checker.check_divergence_condition(
+                div_condition = eqlb_checker.check_divergence_condition(
                     stress_eq,
                     stress_projected,
                     rhs_projected,
@@ -156,12 +159,23 @@ def test_equilibration_conditions(mesh_type, degree, bc_type):
                     flux_is_dg=True,
                 )
 
+                if not div_condition:
+                    raise ValueError("Divergence conditions not fulfilled")
+
                 # --- Check jump condition (only required for semi-explicit equilibrator)
                 for i in range(geometry.mesh.geometry.dim):
-                    eqlb_checker.check_jump_condition(sigma_eq[i], sigma_projected[i])
+                    jump_condition = eqlb_checker.check_jump_condition(
+                        sigma_eq[i], sigma_projected[i]
+                    )
+
+                    if not jump_condition:
+                        raise ValueError("Boundary conditions not fulfilled")
 
                 # --- Check weak symmetry
-                eqlb_checker.check_weak_symmetry_condition(sigma_eq)
+                wsym_condition = eqlb_checker.check_weak_symmetry_condition(sigma_eq)
+
+                if not wsym_condition:
+                    raise ValueError("Weak symmetry conditions not fulfilled")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fix memory issue on meshes with patches with uneven number of cells
* Generalise grouping of 2 cell patches on Neumann boundary
* Enable eqlb. on general meshes (with reversed facets)
* Add unit test for stress eqlb. with general boundary conditions

Closes #1, closes #6, closes #7